### PR TITLE
LCIO defaults and key4hep-stack update

### DIFF
--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -23,13 +23,13 @@ class Key4hepStack(BundlePackage):
     depends_on('lcio')
     depends_on('lcgeo')
 
-    # 
+    # be explicit to avoid concretizer errors
     depends_on('root cxxstd=17 +root7 +ssl')
     depends_on('boost +python')
 
-    # there are known issues with compilers from red hat's devtoolset
-    # which are therefore not supported
-    # https://root-forum.cern.ch/t/devtoolset-gcc-toolset-compatibility/38286
-    conflicts("gcc@8.3.1")
+    conflicts("%gcc@8.3.1",
+              msg="There are known issues with compilers from redhat's devtoolsets" \
+              "which are therefore not supported." \
+              "See https://root-forum.cern.ch/t/devtoolset-gcc-toolset-compatibility/3828 ")
 
     

--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -30,6 +30,6 @@ class Key4hepStack(BundlePackage):
     conflicts("%gcc@8.3.1",
               msg="There are known issues with compilers from redhat's devtoolsets" \
               "which are therefore not supported." \
-              "See https://root-forum.cern.ch/t/devtoolset-gcc-toolset-compatibility/3828 ")
+              "See https://root-forum.cern.ch/t/devtoolset-gcc-toolset-compatibility/38286")
 
     

--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -9,14 +9,27 @@ class Key4hepStack(BundlePackage):
     
     version('0.1')
     version('nightly')
+
     
     depends_on('podio@master', when="@nightly")
     depends_on('edm4hep@master', when="@nightly")
     depends_on('K4FWCore@master', when="@nightly")
     depends_on('guinea-pig@master', when="@nightly")
-    depends_on('dd4hep@master', when='@nightly')
     
     depends_on("edm4hep@0.1.0", when="@0.1")
     depends_on("K4FWCore@0.1.0", when="@0.1")
     depends_on('guinea-pig@1.2.2rc', when="@0.1")
+
+    depends_on('lcio')
+    depends_on('lcgeo')
+
+    # 
+    depends_on('root cxxstd=17 +root7 +ssl')
+    depends_on('boost +python')
+
+    # there are known issues with compilers from red hat's devtoolset
+    # which are therefore not supported
+    # https://root-forum.cern.ch/t/devtoolset-gcc-toolset-compatibility/38286
+    conflicts("gcc@8.3.1")
+
     

--- a/packages/lcio/package.py
+++ b/packages/lcio/package.py
@@ -22,14 +22,14 @@ class Lcio(CMakePackage):
 
     variant('cxxstd',
             default='17',
-            values=('14', '17'),
+            values=('11', '14', '17'),
             multi=False,
             description='Use the specified C++ standard when building.')
     variant("jar", default=False,
     description="Turn on to build/install lcio.jar")
-    variant("rootdict", default=False,
+    variant("rootdict", default=True,
     description="Turn on to build/install ROOT dictionary.")
-    variant("examples", default=True,
+    variant("examples", default=False,
     description="Turn on to build LCIO examples")
 
     depends_on('root@6.04:', when="+rootdict")


### PR DESCRIPTION
@tmadlener this should work around the cxxstd concretizer error.