### PR TITLE
Fixes for Marlin

### DIFF
--- a/packages/conddbmysql/package.py
+++ b/packages/conddbmysql/package.py
@@ -20,7 +20,7 @@ class Conddbmysql(CMakePackage):
 
 
 
-    depends_on("mysql")
+    depends_on("mariadb")
     depends_on("ilcutil")
 
 

--- a/packages/gear/package.py
+++ b/packages/gear/package.py
@@ -26,6 +26,7 @@ class Gear(CMakePackage):
 
 
     depends_on("ilcutil")
+    depends_on("clhep")
     depends_on("root", when="+tgeo")
     depends_on("doxygen", when="+doc")
 

--- a/packages/ilcutil/installdoc.patch
+++ b/packages/ilcutil/installdoc.patch
@@ -1,0 +1,23 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bee5cb8..bf3ecca 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -15,6 +15,8 @@ SET( ${PROJECT_NAME}_VERSION_MINOR 6 )
+ SET( ${PROJECT_NAME}_VERSION_PATCH 0 )
+ 
+ 
++OPTION( INSTALL_DOC "Set to OFF to skip build/install Documentation" OFF )
++
+ LIST( APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmakemodules" )
+ INCLUDE( ilcsoft_default_settings )
+ 
+@@ -36,7 +38,7 @@ ExternalProject_Add( cmakemodules
+ 
+ ExternalProject_Add( streamlog
+     SOURCE_DIR "${PROJECT_SOURCE_DIR}/streamlog"
+-    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DCMAKE_MODULE_PATH=${PROJECT_SOURCE_DIR}/cmakemodules -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD} -DUSE_CXX11=${USE_CXX11}
++    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DCMAKE_MODULE_PATH=${PROJECT_SOURCE_DIR}/cmakemodules -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD} -DUSE_CXX11=${USE_CXX11} -DINSTALL_DOC=${INSTALL_DOC}
+     INSTALL_COMMAND ${CMAKE_BUILD_TOOL} install
+ )
+ 
+

--- a/packages/ilcutil/package.py
+++ b/packages/ilcutil/package.py
@@ -18,6 +18,8 @@ class Ilcutil(CMakePackage):
     version('master', branch='master')
     version('1.6.0', sha256='09083890721704f39a3e902dc660db5326027cc38446b813233d04ec3233ba2e')
 
+    patch("installdoc.patch")
+
     def url_for_version(self, version):
         # releases are dashed and padded with a leading zero
         # the patch version is omitted when 0

--- a/packages/lccd/package.py
+++ b/packages/lccd/package.py
@@ -23,6 +23,7 @@ class Lccd(CMakePackage):
 
 
     depends_on("ilcutil")
+    depends_on("lcio")
     depends_on("conddbmysql", when="+conddbmysql")
 
 

--- a/packages/marlin/package.py
+++ b/packages/marlin/package.py
@@ -54,6 +54,8 @@ class Marlin(CMakePackage):
         args.append(self.define_from_variant('MARLIN_LCCD', 'clhep'))
         args.append(self.define_from_variant('MARLIN_AIDA', 'aida'))
         args.append('-DCMAKE_CXX_STANDARD=17')
+        if 'aida' in self.spec:
+          args.append('-DAIDA_DIR=%s' % self.spec["aida"].prefix)
         return args
 
     def url_for_version(self, version):

--- a/packages/marlin/package.py
+++ b/packages/marlin/package.py
@@ -42,7 +42,7 @@ class Marlin(CMakePackage):
     depends_on("qt4", when="+gui")
     depends_on("lccd", when="+lccd")
     depends_on("clhep", when="+clhep")
-    depends_on("aida", when="+aida")
+    depends_on("raida", when="+aida")
 
 
     def cmake_args(self):

--- a/packages/raida/package.py
+++ b/packages/raida/package.py
@@ -1,0 +1,45 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Raida(CMakePackage):
+    """ A utility package for the iLCSoft software framework """
+
+    homepage = "https://github.com/iLCSoft/raida"
+    git      = "https://github.com/iLCSoft/raida.git"
+    url      = "https://github.com/iLCSoft/raida/archive/v01-06.tar.gz"
+
+    maintainers = ['vvolkl']
+
+    version('master', branch='master')
+    version('1.9.0', sha256='53ad3fd7c62e5eba70e6d6099e5ef4d92920399afb7b31dc8008b6ad865a9e85')
+
+
+    depends_on('ilcutil')
+    depends_on("root")
+
+    def cmake_args(self):
+        args = []
+        # C++ Standard
+        args.append('-DCMAKE_CXX_STANDARD=%s'
+                    % self.spec['root'].variants['cxxstd'].value)
+        args.append('-DBUILD_TESTING=%s' % self.run_tests)
+        return args
+
+    def url_for_version(self, version):
+        # releases are dashed and padded with a leading zero
+        # the patch version is omitted when 0
+        # so for example v01-12-01, v01-12 ...
+        major = (str(version[0]).zfill(2))
+        minor = (str(version[1]).zfill(2))
+        patch = (str(version[2]).zfill(2))
+        if version[2] == 0:
+            url = "https://github.com/iLCSoft/raida/archive/v%s-%s.tar.gz" % (major, minor)
+        else:
+            url = "https://github.com/iLCSoft/raida/archive/v%s-%s-%s.tar.gz" % (major, minor, patch)
+        return url
+


### PR DESCRIPTION
Marlin now compiles for me -- but only without aida, it does not pick up the spack-installed aida, even when  AIDA_DIR is set. @fdplacido @andresailer could you point me to the `FindAIDA.cmake` iLCsoft is using?

There was one more issue with ilcutil - this failed when doxygen is present on the build machine. I'll make a PR with the patch included here so the cmake option is forwarded from ilcutil.