### PR TITLE
MARLIN_DLL: fix some library names, FCalClusterer

### DIFF
--- a/packages/clupatra/package.py
+++ b/packages/clupatra/package.py
@@ -30,7 +30,7 @@ class Clupatra(CMakePackage):
 
 
     def setup_run_environment(self, spack_env):
-        spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libClupatra  .so")
+        spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libClupatra.so")
 
     def url_for_version(self, version):
        return ilc_url_for_version(self, version)

--- a/packages/ddmarlinpandora/package.py
+++ b/packages/ddmarlinpandora/package.py
@@ -28,7 +28,7 @@ class Ddmarlinpandora(CMakePackage):
     depends_on('marlintrk')
 
     def setup_run_environment(self, spack_env):
-        spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libMarlinDD4hep.so")
+        spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libDDMarlinPandora.so")
 
 
     def url_for_version(self, version):

--- a/packages/fcalclusterer/install.patch
+++ b/packages/fcalclusterer/install.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 41060e7..3d36e9e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -14,7 +14,7 @@ OPTION( FCAL_USE_Marlin  " Build Marlin Processors" True )
+ OPTION( FCAL_USE_DD4hep  " Build With DD4hep support" True )
+ OPTION( INSTALL_DOC "Set to OFF to skip build/install Documentation" OFF )
+ 
+-SET( CMAKE_INSTALL_PREFIX ${PROJECT_SOURCE_DIR} )
++#SET( CMAKE_INSTALL_PREFIX ${PROJECT_SOURCE_DIR} )
+ 
+ FIND_PACKAGE( ILCUTIL 1.3.0 REQUIRED COMPONENTS ILCSOFT_CMAKE_MODULES )
+ # load default settings from ILCSOFT_CMAKE_MODULES

--- a/packages/fcalclusterer/package.py
+++ b/packages/fcalclusterer/package.py
@@ -28,7 +28,7 @@ class Fcalclusterer(CMakePackage):
     depends_on('dd4hep')
 
     # CMAKE_INSTALL_PREFIX is overwritten by the package
-    patch("install.patch")
+    patch("install.patch", when="@:1.0.1")
 
     def cmake_args(self):
         args = []

--- a/packages/fcalclusterer/package.py
+++ b/packages/fcalclusterer/package.py
@@ -27,6 +27,9 @@ class Fcalclusterer(CMakePackage):
     depends_on('root +unuran +math')
     depends_on('dd4hep')
 
+    # CMAKE_INSTALL_PREFIX is overwritten by the package
+    patch("install.patch")
+
     def cmake_args(self):
         args = []
         # C++ Standard
@@ -35,10 +38,10 @@ class Fcalclusterer(CMakePackage):
         args.append('-DBUILD_TESTING=%s' % self.run_tests)
         return args
 
-    def install(self, spec, prefix):
+    @run_after('install')
+    def install_source(self):
         #make('install')
         install_tree('.', self.prefix)
-
 
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libFCalClusterer.so")

--- a/packages/lcfiplus/dict.patch
+++ b/packages/lcfiplus/dict.patch
@@ -1,0 +1,11 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a2f88db..3cf7cc2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -39,6 +39,7 @@ INCLUDE_DIRECTORIES( SYSTEM ${LCFIVertex_INCLUDE_DIRS} )
+ # left here for backwards compatibility
+ INCLUDE_DIRECTORIES( SYSTEM ${LCFIVertex_ROOT}/vertex_lcfi ${LCFIVertex_ROOT}/boost )
+
++SET( ROOT_DICT_CINT_DEFINITIONS -noIncludePaths -inlineInputHeader -I${PROJECT_SOURCE_DIR}/include )
+ #INCLUDE( ${ROOT_DICT_MACROS_FILE} )
+ INCLUDE( "${ILCUTIL_ROOT}/cmakemodules/MacroRootDict.cmake" )

--- a/packages/lcfiplus/package.py
+++ b/packages/lcfiplus/package.py
@@ -25,15 +25,20 @@ class Lcfiplus(CMakePackage):
     depends_on('lcfivertex')
     depends_on('root +tmva')
 
+    patch("dict.patch")
+
     def cmake_args(self):
         args = []  
         # todo: add variant
         args.append(self.define('INSTALL_DOC', False))
         return args
 
+    @run_after('install')
+    def install_source(self):
+        install_tree('include', self.prefix.include)
 
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libLCFIPlus.so")
 
     def url_for_version(self, version):
-       return ilc_url_for_version(self, version)
+        return ilc_url_for_version(self, version)

--- a/packages/marlindd4hep/package.py
+++ b/packages/marlindd4hep/package.py
@@ -29,7 +29,7 @@ class Marlindd4hep(CMakePackage):
         return args
 
     def setup_run_environment(self, spack_env):
-        spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libMarlinDD4hep.so.so")
+        spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libMarlinDD4hep.so")
 
     def url_for_version(self, version):
        return ilc_url_for_version(self, version)


### PR DESCRIPTION
Fixes:
* some libraries added to MARLIN_DLL
* Installation of FCalClusterer libraries
* Dictionary issues for LCFIPlus

After these changes I can run
`Marlin` and it loads all the libraries in MARLIN_DLL. There are, however, warnings for the physsim and kaltest (MarlinTrkProcessors) libraries from Cling autoloader because some of missing header files.