### PR TITLE
ilcsoft dictionary fixes: kaldet, kaltest, physsim

### DIFF
--- a/packages/kaldet/dict.patch
+++ b/packages/kaldet/dict.patch
@@ -1,0 +1,11 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c72fd9d..8be04af 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -55,7 +55,7 @@ ADD_DEFINITIONS( "-Wno-effc++ -Wno-unused-parameter" )
+
+
+ # macros for generating root dict sources with rootcint
+-SET( ROOT_DICT_CINT_DEFINITIONS "-DHANDLE_DICT_EXCEPTIONS=IGNORED_FOR_CINT" )
++SET( ROOT_DICT_CINT_DEFINITIONS -DHANDLE_DICT_EXCEPTIONS=IGNORED_FOR_CINT -inlineInputHeader -noIncludePaths)
+ INCLUDE( "${ILCUTIL_ROOT}/cmakemodules/MacroRootDict.cmake" )

--- a/packages/kaldet/package.py
+++ b/packages/kaldet/package.py
@@ -30,6 +30,8 @@ class Kaldet(CMakePackage):
     depends_on('kaltest')
     depends_on('root')
 
+    patch("dict.patch")
+
     def cmake_args(self):
         args = []
         # C++ Standard
@@ -37,6 +39,9 @@ class Kaldet(CMakePackage):
                     % self.spec['root'].variants['cxxstd'].value)
         args.append('-DBUILD_TESTING=%s' % self.run_tests)
         return args
+
+    def setup_run_environment(self, spack_env):
+        spack_env.prepend_path('CPATH', self.prefix.include.kaldet)
 
     def url_for_version(self, version):
        return ilc_url_for_version(self, version)

--- a/packages/kaltest/dict.patch
+++ b/packages/kaltest/dict.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4abcabb..a0418f1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -29,7 +29,7 @@ INCLUDE( ilcsoft_default_settings )
+
+
+ # macros for generating root dict sources with rootcint
+-SET( ROOT_DICT_CINT_DEFINITIONS "-DHANDLE_DICT_EXCEPTIONS=IGNORED_FOR_CINT" )
++SET( ROOT_DICT_CINT_DEFINITIONS -DHANDLE_DICT_EXCEPTIONS=IGNORED_FOR_CINT -inlineInputHeader -noIncludePaths )
+
+ #  ROOTConfig.cmake uses a different name for rootcint than we used to in FINDROOT.cmake
+ #SET( ROOT_CINT_EXECUTABLE ${ROOT_rootcint_CMD} )

--- a/packages/kaltest/package.py
+++ b/packages/kaltest/package.py
@@ -28,6 +28,8 @@ class Kaltest(CMakePackage):
     depends_on('ilcutil')
     depends_on('root')
 
+    patch("dict.patch")
+
     def cmake_args(self):
         args = []
         # C++ Standard
@@ -36,5 +38,10 @@ class Kaltest(CMakePackage):
         args.append('-DBUILD_TESTING=%s' % self.run_tests)
         return args
 
+    def setup_run_environment(self, spack_env):
+        # The dictionary headers required kaltest to be in CPATH or ROOT_INCLUDE_PATH
+        # other libraries require include to be searchable (which is automatic)
+        spack_env.prepend_path('CPATH', self.prefix.include.kaltest)
+
     def url_for_version(self, version):
-       return ilc_url_for_version(self, version)
+        return ilc_url_for_version(self, version)

--- a/packages/physsim/dict.patch
+++ b/packages/physsim/dict.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9345ca8..61dcd01 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -32,7 +32,7 @@ FIND_PACKAGE( ROOT REQUIRED )
+
+
+ # macros for generating root dict sources with rootcint
+-SET( ROOT_DICT_CINT_DEFINITIONS "-DHANDLE_DICT_EXCEPTIONS=IGNORED_FOR_CINT" )
++SET( ROOT_DICT_CINT_DEFINITIONS -DHANDLE_DICT_EXCEPTIONS=IGNORED_FOR_CINT -noIncludePaths -inlineInputHeader )
+ INCLUDE( "${ILCUTIL_ROOT}/cmakemodules/MacroRootDict.cmake" )
+

--- a/packages/physsim/package.py
+++ b/packages/physsim/package.py
@@ -21,8 +21,14 @@ class Physsim(CMakePackage):
     depends_on('ilcutil')
     depends_on('root')
 
+    patch("dict.patch")
+
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libPhyssim.so")
+
+    def setup_run_environment(self, spack_env):
+        # The dictionary headers require physsim to be in CPATH or ROOT_INCLUDE_PATH
+        spack_env.prepend_path('CPATH', self.prefix.include.physsim)
 
     def cmake_args(self):
         args = []


### PR DESCRIPTION
With these changes all the warnings from cling autoloader disappear when Marlin loads the processors from MARLIN_DLL