### PR TITLE
add lcio variant for dd4hep

### DIFF
--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -16,7 +16,7 @@ class Key4hepStack(BundlePackage):
     depends_on('K4FWCore@master', when="@nightly")
     depends_on('guinea-pig@master', when="@nightly")
     depends_on('lcgeo', when="@nightly")
-    depends_on("dd4hep@master", when="@nightly")
+    depends_on("dd4hep@master +lcio", when="@nightly")
     
     depends_on("edm4hep@0.2.0", when="@0.1")
     depends_on("K4FWCore@0.1.0", when="@0.1")
@@ -24,6 +24,7 @@ class Key4hepStack(BundlePackage):
     depends_on('whizard +lcio +openloops', when="@0.1")
 
     depends_on('lcio', when="@0.1")
+    depends_on('dd4hep +lcio', when="@0.1")
     depends_on('lcgeo', when="@0.1")
 
     depends_on('marlin', when="@0.1")


### PR DESCRIPTION
~~This adds the lcio variant for the requirement of lcgeo on dd4hep.
Not sure this is the best place to put this?~~

Added explicit dependency in the key4hep stack on dd4hep+lcio
I think at least this is a better place to put this than lcgeo

PR to add the lcio variant to the dd4hep spack recipe.
https://github.com/spack/spack/pull/18691