### PR TITLE
Add CEPCSW into k4-spack

### DIFF
--- a/packages/cepcsw/package.py
+++ b/packages/cepcsw/package.py
@@ -1,14 +1,4 @@
 # ----------------------------------------------------------------------------
-# Install CEPCSW via spack
-#
-#     spack install cepcsw
-#
-# You can edit this file again by typing:
-#
-#     spack edit cepcsw
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
 
 from spack import *
 from spack.pkg.k4.Ilcsoftpackage import k4_add_latest_commit_as_version 

--- a/packages/cepcsw/package.py
+++ b/packages/cepcsw/package.py
@@ -52,10 +52,6 @@ class Cepcsw(CMakePackage):
         if self.spec.satisfies('^gaudi@:34.99'):
             args.append('-DHOST_BINARY_TAG=x86_64-linux-gcc9-opt')
 
-        clhep_prefix = self.spec["clhep"].prefix
-        clhep_include = clhep_prefix + "/include"
-        args.append('-DCLHEP_INCLUDE_DIR=%s'%clhep_include)
-
         pandorapfa_prefix = self.spec["pandorapfa"].prefix
         pandorapfa_cmake_modules = pandorapfa_prefix + "/cmakemodules"
 

--- a/packages/cepcsw/package.py
+++ b/packages/cepcsw/package.py
@@ -1,0 +1,79 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install cepcsw
+#
+# You can edit this file again by typing:
+#
+#     spack edit cepcsw
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack import *
+
+
+class Cepcsw(CMakePackage):
+    """FIXME: Put a proper description of your package here."""
+
+    # FIXME: Add a proper url for your package's homepage here.
+    homepage = "https://github.com/cepc/CEPCSW"
+    url      = "https://github.com/cepc/CEPCSW/archive/master.zip"
+    git      = "https://github.com/cepc/CEPCSW.git"
+
+    # FIXME: Add a list of GitHub accounts to
+    # notify when the package is updated.
+    maintainers = ['mirguest']
+
+
+    variant('cxxstd',
+            default='17',
+            values=('14', '17'),
+            multi=False,
+            description='Use the specified C++ standard when building.')
+
+    # FIXME: Add proper versions here.
+    # version('1.2.4')
+    version('master', branch='master')
+
+    # FIXME: Add dependencies if required.
+    depends_on('clhep')
+    depends_on('dd4hep +geant4')
+    depends_on('edm4hep')
+    depends_on('k4fwcore')
+    depends_on('gaudi')
+    depends_on('gear')
+    depends_on('lcio')
+    depends_on('lccontent')
+    depends_on('pandorasdk')
+    depends_on('pandorapfa')
+    depends_on('podio')
+    depends_on('root')
+
+    def cmake_args(self):
+        args = []
+        # C++ Standard
+        args.append('-DCMAKE_CXX_STANDARD=%s'%self.spec.variants['cxxstd'].value)
+        if self.spec.satisfies('^gaudi@:34.99'):
+            args.append('-DHOST_BINARY_TAG=x86_64-linux-gcc9-opt')
+
+        clhep_prefix = self.spec["clhep"].prefix
+        clhep_include = clhep_prefix + "/include"
+        args.append('-DCLHEP_INCLUDE_DIR=%s'%clhep_include)
+
+        pandorapfa_prefix = self.spec["pandorapfa"].prefix
+        pandorapfa_cmake_modules = pandorapfa_prefix + "/cmakemodules"
+
+        cmake_modules = pandorapfa_cmake_modules
+        args.append('-DCMAKE_MODULE_PATH=%s'%cmake_modules)
+        return args

--- a/packages/cepcsw/package.py
+++ b/packages/cepcsw/package.py
@@ -11,6 +11,7 @@
 # ----------------------------------------------------------------------------
 
 from spack import *
+from spack.pkg.k4.Ilcsoftpackage import k4_add_latest_commit_as_version 
 
 
 class Cepcsw(CMakePackage):

--- a/packages/cepcsw/package.py
+++ b/packages/cepcsw/package.py
@@ -1,15 +1,5 @@
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
-# Spack Project Developers. See the top-level COPYRIGHT file for details.
-#
-# SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 # ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
+# Install CEPCSW via spack
 #
 #     spack install cepcsw
 #
@@ -24,15 +14,12 @@ from spack import *
 
 
 class Cepcsw(CMakePackage):
-    """FIXME: Put a proper description of your package here."""
+    """CEPC offline experiment software based on Key4hep."""
 
-    # FIXME: Add a proper url for your package's homepage here.
     homepage = "https://github.com/cepc/CEPCSW"
-    url      = "https://github.com/cepc/CEPCSW/archive/master.zip"
+    url      = "https://github.com/cepc/CEPCSW/archive/v0.1.tar.gz"
     git      = "https://github.com/cepc/CEPCSW.git"
 
-    # FIXME: Add a list of GitHub accounts to
-    # notify when the package is updated.
     maintainers = ['mirguest']
 
 
@@ -42,11 +29,9 @@ class Cepcsw(CMakePackage):
             multi=False,
             description='Use the specified C++ standard when building.')
 
-    # FIXME: Add proper versions here.
-    # version('1.2.4')
+    k4_add_latest_commit_as_version(git)
     version('master', branch='master')
 
-    # FIXME: Add dependencies if required.
     depends_on('clhep')
     depends_on('dd4hep +geant4')
     depends_on('edm4hep')

--- a/packages/cepcsw/package.py
+++ b/packages/cepcsw/package.py
@@ -43,7 +43,6 @@ class Cepcsw(CMakePackage):
     depends_on('lccontent')
     depends_on('pandorasdk')
     depends_on('pandorapfa')
-    depends_on('podio')
     depends_on('root')
 
     def cmake_args(self):

--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -205,6 +205,12 @@ class Key4hepStack(BundlePackage):
     depends_on("dual-readout")
     k4_add_latest_commit_as_dependency("dual-readout", "hep-fcc/dual-readout", when="@master")
 
+    ############################## cepcsw #################
+    #######################################################
+    depends_on("cepcsw")
+    k4_add_latest_commit_as_dependency("cepcsw", "cepc/cepcsw", when="@master")
+
+
     ##################### developer tools #################
     #######################################################
     depends_on("cmake", when="+devtools")


### PR DESCRIPTION
Currently, [CEPCSW](https://github.com/cepc/CEPCSW) depends on LCG 97 + CEPC maintained external libraries. To make CEPCSW work with the spack, I have created a branch named `key4hep` in [my CEPCSW repo](https://github.com/mirguest/CEPCSW/tree/k4spack). In the near future, I will work on make the CEPCSW compiled both on LCG release and key4hep stack (See issue https://github.com/cepc/CEPCSW/issues/53). 

The procedures to build CEPCSW using spack:
```
source /cvmfs/sw.hsf.org/key4hep/setup.sh

cat <<EOT >> $HOME/.spack/linux/upstreams.yaml
upstreams:
  spack-instance-1:
      install_tree: /cvmfs/sw.hsf.org/spackages/
EOT

spack install cepcsw
```