### PR TITLE
Use the latest version for whizard

### DIFF
--- a/config/packages.yaml
+++ b/config/packages.yaml
@@ -26,9 +26,6 @@ packages:
   ocaml:
     version: [4.10.0]
     variants: ~force-safe-string
-  # Newer versions currently do not build
-  whizard:
-    version: [2.8.4]
   # Avoid concretizer conflict for edm4hep
   pythia8:
     version: [8244]


### PR DESCRIPTION
I wrongly attributed the build failure to the version of `whizard`, when in fact it was #71. We can indeed also use the latest 2.8.5 version.