### PR TITLE
Fix build failure by hardcoding the c++std

### DIFF
--- a/packages/fcc-edm/package.py
+++ b/packages/fcc-edm/package.py
@@ -43,7 +43,7 @@ class FccEdm(CMakePackage):
     def cmake_args(self):
         args = []
         # C++ Standard
-        args.append('-DCMAKE_CXX_STANDARD=%s' % self.spec.variants['cxxstd'].value)
+        args.append('-DCMAKE_CXX_STANDARD=17')
         return args
 
     # Override pre-defined test step


### PR DESCRIPTION
cxxstd variant has been removed in #75 but the only available value before was 17