### PR TITLE
Add doxygen to key4hep-stack, fcc-edm fix

### DIFF
--- a/packages/fcc-edm/package.py
+++ b/packages/fcc-edm/package.py
@@ -43,7 +43,7 @@ class FccEdm(CMakePackage):
     def cmake_args(self):
         args = []
         # C++ Standard
-        args.append('-DCMAKE_CXX_STANDARD=%s' % self.spec.variants['cxxstd'].value)
+        args.append('-DCMAKE_CXX_STANDARD=17')
         return args
 
     # Override pre-defined test step

--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -218,6 +218,7 @@ class Key4hepStack(BundlePackage):
     depends_on("emacs+X toolkit=athena", when="+devtools")
     depends_on("ninja", when="+devtools")
     depends_on("py-ipython", when="+devtools")
+    depends_on("doxygen", when="+devtools")
 
     ##################### environment boostrap ############
     #######################################################


### PR DESCRIPTION
* Doxygen is used by some of the package and should be included in the builds
* Fix a failure of the nightly builds