### PR TITLE
Automatic generation of the setup script in the install phase of the bundle package

### DIFF
--- a/packages/Ilcsoftpackage/package.py
+++ b/packages/Ilcsoftpackage/package.py
@@ -39,7 +39,8 @@ def k4_generate_setup_script(env_mod, shell='sh'):
     """
     modifications = env_mod.group_by_name()
     new_env = {}
-    env_set_not_prepend = {}
+    # keep track wether this variable is supposed to be a list of paths, or set to a single value
+    env_prepend_not_set = {} 
     for name, actions in sorted(modifications.items()):
         env_prepend_not_set[name] = True 
         for x in actions:

--- a/packages/Ilcsoftpackage/package.py
+++ b/packages/Ilcsoftpackage/package.py
@@ -40,14 +40,14 @@ def k4_generate_setup_script(env_mod, shell='sh'):
     modifications = env_mod.group_by_name()
     new_env = {}
     # keep track wether this variable is supposed to be a list of paths, or set to a single value
-    env_prepend_not_set = {} 
+    env_set_not_prepend = {} 
     for name, actions in sorted(modifications.items()):
-        env_prepend_not_set[name] = True 
+        env_set_not_prepend[name] = False
         for x in actions:
-            env_prepend_not_set[name] = env_prepend_not_set[name] and isinstance(x, (SetPath, SetEnv))
+            env_set_not_prepend[name] = env_set_not_prepend[name] or isinstance(x, (SetPath, SetEnv))
             # set a dictionary with the environment variables
             x.execute(new_env)
-        if env_prepend_not_set[name] and len(actions) > 1:
+        if env_set_not_prepend[name] and len(actions) > 1:
             tty.warn("Var " + name + "is set multiple times!" )
   
     # deduplicate paths
@@ -66,7 +66,7 @@ def k4_generate_setup_script(env_mod, shell='sh'):
     }
     cmds = []
     for name in set(new_env):
-        if not env_prepend_not_set[name]:
+        if env_set_not_prepend[name]:
             cmds += [k4_shell_set_strings[shell].format(
                 name, cmd_quote(new_env[name]))]
         else:

--- a/packages/Ilcsoftpackage/package.py
+++ b/packages/Ilcsoftpackage/package.py
@@ -28,24 +28,27 @@ k4_shell_prepend_strings = {
 
 
 
-def key4hep_setup_script(self, shell='sh'):
+def k4_generate_setup_script(self, shell='sh'):
     """Return shell code to apply the modifications and clears the list."""
+    # first, deduplecate paths
+    #modifications = self.group_by_name()
+    #for name, actions in sorted(modifications.items()):
+    #  self.prune_duplicate_paths(name)
+    # second, keep track if the paths should be set or prepended
     modifications = self.group_by_name()
-    new_env = {} # os.environ.copy()
-
+    new_env = {}
     env_set_not_prepend = {}
-
     for name, actions in sorted(modifications.items()):
         for x in actions:
             if isinstance(x, SetPath) or isinstance(x, SetEnv):
               env_set_not_prepend[name] = True
             else:
               env_set_not_prepend[name] = False
-            
+            # third, actually set an environment
             x.execute(new_env)
 
+    # fourth, get shell commands
     cmds = ''
-
     for name in set(new_env):
       if env_set_not_prepend[name]:
                 cmds += k4_shell_set_strings[shell].format(

--- a/packages/fccsw/package.py
+++ b/packages/fccsw/package.py
@@ -84,6 +84,6 @@ class Fccsw(CMakePackage):
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('PYTHONPATH', self.prefix.python)
         spack_env.prepend_path("PATH", self.prefix.scripts)
-        spack_env.set_path("FCCSWBASEDIR", self.prefix)
-        spack_env.set_path("FCC_DETECTORS", self.prefix.share.FCCSW)
-        spack_env.set_path("FCCSW", self.prefix.share.FCCSW)
+        spack_env.set("FCCSWBASEDIR", self.prefix)
+        spack_env.set("FCC_DETECTORS", self.prefix.share.FCCSW)
+        spack_env.set("FCCSW", self.prefix.share.FCCSW)

--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -245,7 +245,8 @@ class Key4hepStack(BundlePackage):
           env_mod.extend(uenv.environment_modifications_for_spec(spec))
           env_mod.prepend_path(uenv.spack_loaded_hashes_var, spec.dag_hash())
       cmds = key4hep_setup_script(env_mod)
-      print(cmds)
+      with open(os.path.join(prefix, "setup.sh")) as f:
+        f.write(cmds)
 
 
    

--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -20,6 +20,8 @@ class Key4hepStack(BundlePackage):
     version(datetime.today().strftime('%Y-%m-%d'))
     #version('2020-10-06') # example, no need to add them here
 
+    phases = ['install']
+
     ##################### variants ########################
     #######################################################
     variant('devtools', default=True,
@@ -231,5 +233,21 @@ class Key4hepStack(BundlePackage):
               msg="There are known issues with compilers from redhat's devtoolsets" \
               "which are therefore not supported." \
               "See https://root-forum.cern.ch/t/devtoolset-gcc-toolset-compatibility/38286")
+
+    def install(self, spec, prefix):
+      specs = [spec]
+      with spack.store.db.read_transaction():
+               specs = [dep for spec in specs
+                        for dep in
+                        spec.traverse( order='post')]
+      env_mod = spack.util.environment.EnvironmentModifications()
+      for spec in specs:
+          env_mod.extend(uenv.environment_modifications_for_spec(spec))
+          env_mod.prepend_path(uenv.spack_loaded_hashes_var, spec.dag_hash())
+      cmds = key4hep_setup_script(env_mod)
+      print(cmds)
+
+
+   
 
     

--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -262,12 +262,15 @@ class Key4hepStack(BundlePackage):
       with open(os.path.join(prefix, "setup.sh"), "w") as f:
         f.write(cmds)
       if "+key4hep_symlink" in spec:
+        try:
           symlink_path = os.environ.get("K4_LATEST_SETUP", "/cvmfs/sw.hsf.org/spackages/latest/setup.sh")
           if not os.path.exists(os.path.dirname(symlink_path)):
             os.makedirs(os.path.dirname(symlink_path))
           if os.path.exists(symlink_path):
             os.remove(symlink_path)
           os.symlink(os.path.join(prefix, "setup.sh"), symlink_path)
+        except:
+          print("Could not create symlink")
 
 
    


### PR DESCRIPTION
This PR 
* adds a method "k4_generate_setup_script" to Ilcsoftpackage (which is becoming a library for custom spack functions). This is similar to `spack load --sh package > setup.sh` but does not evaluate the current environment (see docstring)
* adds an install phase to key4hep-stack, to do previously manual steps for an installation:
    - run k4_generate_setup_script and create  a bash setup script in its prefix
    - which also (optionally) sets up gcc since it cannot be a direct dependency
    - create a symlink to the setup script
