### PR TITLE
Update pythia version to 8303

### DIFF
--- a/config/packages.yaml
+++ b/config/packages.yaml
@@ -28,7 +28,7 @@ packages:
     variants: ~force-safe-string
   # Avoid concretizer conflict for edm4hep
   pythia8:
-    version: [8244]
+    version: [8303]
   # gaudi v34 does not work with python 3.8
   # setting the version explicitly avoids concretizer errors
   python:

--- a/packages/fccsw/package.py
+++ b/packages/fccsw/package.py
@@ -12,6 +12,7 @@ class Fccsw(CMakePackage):
 
     version('master', branch='master')
     k4_add_latest_commit_as_version(git)
+    version('0.16pre02', tag='v0.16pre02')
     version('0.15', sha256='89d17e2a91459844a433516e351ecae7fe288563621e9c5cb4f7a801fd24fc2c')
     version('0.13', sha256='4b76b28404f02dac09d9b02eb1db9926f5a53b21c6b91e95d3812267d575b116')
     version('0.12', sha256='a67151c12177882abd8afcf56bee47c2830c44cac749b23d08d005b45096b264')

--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -208,8 +208,8 @@ class Key4hepStack(BundlePackage):
     depends_on("fcc-edm")
     k4_add_latest_commit_as_dependency("fcc-edm", "hep-fcc/fcc-edm", when="@master")
 
-    depends_on("dual-readout")
-    k4_add_latest_commit_as_dependency("dual-readout", "hep-fcc/dual-readout", when="@master")
+    #depends_on("dual-readout")
+    #k4_add_latest_commit_as_dependency("dual-readout", "hep-fcc/dual-readout", when="@master")
 
     ############################## cepcsw #################
     #######################################################


### PR DESCRIPTION
From the pythia homepage:
>  With 8.302 the code should be sufficiently well tested to offer a fully functional upgrade from the 8.2 series, and starting with 8.303 new physics features are being introduced that should make 8.3 the natural choice. 

also, the namespaces in the EvtGen plugin headers are fixed, which will be necessary for some fcc studies.