### PR TITLE
fix symlink creation for bundle package

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,7 +51,7 @@ build-spack-nightlies:
         # compiler setup 
         - spack load gcc
         - spack compiler find --scope site
-        - export K4_LATEST_SETUP_PATH=/cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh
+        - export K4_LATEST_SETUP_PATH=/cvmfs/sw-nightlies.hsf.org/spackages/latest/setup.sh
         # compile onwards and upwards
         # use hash of currently installed dd4hep to avoid rebuilding everything 
         - spack install key4hep-stack@master-`date -I` ^/pnixyp3tfmn
@@ -98,7 +98,7 @@ build-spack-release:
         - spack compiler find --scope site
         # compile onwards and upwards
         # use hash of currently installed dd4hep to avoid rebuilding everything 
-        - export K4_LATEST_SETUP_PATH=/cvmfs/sw.hsf.org/key4hep/setup.sh
+        - export K4_LATEST_SETUP_PATH=/cvmfs/sw.hsf.org/spackages/latest/setup.sh
         - spack install key4hep-stack@`date -I`
 
 deploy-cvmfs-release:

--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -265,7 +265,7 @@ class Key4hepStack(BundlePackage):
           if symlink_path:
               if not os.path.exists(os.path.dirname(symlink_path)):
                 os.makedirs(os.path.dirname(symlink_path))
-              if os.path.exists(symlink_path):
+              if os.path.exists(symlink_path) or os.path.islink(symlink_path):
                 os.remove(symlink_path)
               os.symlink(os.path.join(prefix, "setup.sh"), symlink_path)
         except:


### PR DESCRIPTION
If a broken symlink already exsted at the specified location, the install step wouldn't overwrite it. This fixes this and uses the location `.../spackages/latest/setup.sh` in order to just have to rsync `../spackages`