### PR TITLE
Add SPACK_VERSION parameter to gitlab workflow

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -88,8 +88,9 @@ build-spack-release:
           - $K4_JOBTYPE == "Release"
     script:
         # set up spack inside the k4-spack repo
-        - git clone --depth 1 https://github.com/key4hep/spack
-        - if [ -n "$SPACK_VERSION" ]; then cd spack; git checkout $SPACK_VERSION; cd ..; fi 
+        - if [ -n "$SPACK_VERSION" ]; then git clone  https://github.com/key4hep/spack
+; cd spack; git checkout $SPACK_VERSION; cd ..; else git clone --depth 1 https://github.com/key4hep/spack
+ fi 
         - source spack/share/spack/setup-env.sh
         # register k4 package recipes with spack
         - spack repo add --scope site .

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,7 @@
 variables:
   GIT_STRATEGY: clone
   K4_JOBTYPE: Nightlies
+  SPACK_VERSION: 
 
 stages:
     - compilation
@@ -41,6 +42,7 @@ build-spack-nightlies:
     script:
         # set up spack inside the k4-spack repo
         - git clone --depth 1 https://github.com/key4hep/spack
+        - if [ -n "$SPACK_VERSION" ]; then cd spack; git checkout $SPACK_VERSION; cd ..; fi 
         - source spack/share/spack/setup-env.sh
         # register k4 package recipes with spack
         - spack repo add --scope site .
@@ -86,6 +88,7 @@ build-spack-release:
     script:
         # set up spack inside the k4-spack repo
         - git clone --depth 1 https://github.com/key4hep/spack
+        - if [ -n "$SPACK_VERSION" ]; then cd spack; git checkout $SPACK_VERSION; cd ..; fi 
         - source spack/share/spack/setup-env.sh
         # register k4 package recipes with spack
         - spack repo add --scope site .

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,8 +41,9 @@ build-spack-nightlies:
           - $K4_JOBTYPE == "Nightlies"
     script:
         # set up spack inside the k4-spack repo
-        - git clone --depth 1 https://github.com/key4hep/spack
-        - if [ -n "$SPACK_VERSION" ]; then cd spack; git checkout $SPACK_VERSION; cd ..; fi 
+        - if [ -n "$SPACK_VERSION" ]; then git clone  https://github.com/key4hep/spack
+; cd spack; git checkout $SPACK_VERSION; cd ..; else git clone --depth 1 https://github.com/key4hep/spack
+ fi 
         - source spack/share/spack/setup-env.sh
         # register k4 package recipes with spack
         - spack repo add --scope site .

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,8 +56,7 @@ build-spack-nightlies:
         - spack compiler find --scope site
         - export K4_LATEST_SETUP_PATH=/cvmfs/sw-nightlies.hsf.org/spackages/latest/setup.sh
         # compile onwards and upwards
-        # use hash of currently installed dd4hep to avoid rebuilding everything 
-        - spack install key4hep-stack@master-`date -I` ^/pnixyp3tfmn
+        - spack install key4hep-stack@master-`date -I` 
 
 
 

--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -1,6 +1,9 @@
 from spack import *
+from spack.main import get_version
+import spack.architecture as architecture
 from datetime import datetime
 import os
+import platform
 import llnl.util.tty as tty
 import spack.user_environment as uenv
 from spack.pkg.k4.Ilcsoftpackage import k4_add_latest_commit_as_dependency 
@@ -243,6 +246,15 @@ class Key4hepStack(BundlePackage):
 
     def install(self, spec, prefix):
       """ Create bash setup script in prefix."""
+
+      # first, log spack version to build-out
+
+      tty.msg('* **Spack:**', get_version())
+      tty.msg('* **Python:**', platform.python_version())
+      tty.msg('* **Platform:**', architecture.Arch(
+          architecture.platform(), 'frontend', 'frontend'))
+
+
       specs = [spec]
       with spack.store.db.read_transaction():
                specs = [dep for _spec in specs


### PR DESCRIPTION
Since the HEAD of the upstream spack repo is likely to break things, I add a parameter to specify the version/commit hash of spack to use for the build.