### PR TITLE
Fixes to bring nightlies back

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ build-spack-nightlies:
           - $K4_JOBTYPE == "Nightlies"
     script:
         # set up spack inside the k4-spack repo
-        - git clone --depth 1 https://github.com/spack/spack
+        - git clone --depth 1 https://github.com/key4hep/spack
         - source spack/share/spack/setup-env.sh
         # register k4 package recipes with spack
         - spack repo add --scope site .
@@ -85,7 +85,7 @@ build-spack-release:
           - $K4_JOBTYPE == "Release"
     script:
         # set up spack inside the k4-spack repo
-        - git clone --depth 1 https://github.com/spack/spack
+        - git clone --depth 1 https://github.com/key4hep/spack
         - source spack/share/spack/setup-env.sh
         # register k4 package recipes with spack
         - spack repo add --scope site .

--- a/config/packages.yaml
+++ b/config/packages.yaml
@@ -37,5 +37,13 @@ packages:
     # includes some fixes to the trackcovariance module that are
     # needed in fccsw
     version: [3.4.3pre05]
+  # for compatibility with tensorflow
+  py-numpy:
+    version: [1.18.5]
+  py-tensorflow:
+    variants: [~cuda~nccl]
+  # build error on centos7 with version 7.1.0
+  fmt:
+    version: [6.1.2]
 
 


### PR DESCRIPTION
To have a more reliable source for spack, I forked it under key4hep/spack with a distinct default branch `key4hep` that is close to develop, and has a few cherry-picked patches.