### PR TITLE
Fix easy to fix things in k4generators config

### DIFF
--- a/packages/k4generatorsconfig/package.py
+++ b/packages/k4generatorsconfig/package.py
@@ -23,7 +23,7 @@ class K4generatorsconfig(CMakePackage):
     depends_on("hepmc3")
     depends_on("heppdt")
     depends_on("pythia8")
-    depends_on("python@3.7:")
+    depends_on("python")
     depends_on("py-pyyaml")
 
     def cmake_args(self):


### PR DESCRIPTION
BEGINRELEASENOTES
- Add `PYTHONPATH` and `PATH` for `k4GeneratorsConfig`

ENDRELEASENOTES

Fixes #617 

The rest of the necessary changes mentioned in #617 have happened in `k4GeneratorsConfig` in the meantime, so this should make it possible to run things from the installed package.