### PR TITLE
k4actstracking: do not depend on acts +identification

### DIFF
--- a/packages/k4actstracking/package.py
+++ b/packages/k4actstracking/package.py
@@ -13,7 +13,7 @@ class K4actstracking(CMakePackage, Key4hepPackage):
 
     version("main", branch="main")
 
-    depends_on("acts+dd4hep+tgeo+identification+json")
+    depends_on("acts+dd4hep+tgeo+json")
     depends_on("gaudi")
     depends_on("root")
     depends_on("edm4hep")


### PR DESCRIPTION
BEGINRELEASENOTES
- k4actstracking: do not depend on acts +identification

ENDRELEASENOTES

Acts does have identification with v35 and beyond. As far as I can tell, identification was never needed.