### PR TITLE
Add dependencies for k4Reco needed after https://github.com/key4hep/k4Reco/pull/23

### DIFF
--- a/packages/k4reco/package.py
+++ b/packages/k4reco/package.py
@@ -27,7 +27,7 @@ class K4reco(CMakePackage, Key4hepPackage):
     depends_on("root")
 
     depends_on("lcio", when="+conformal_tracking")
-    depends_on("ilcutils", when="+conformal_tracking")
+    depends_on("ilcutil", when="+conformal_tracking")
     depends_on("kaltest", when="+conformal_tracking")
     depends_on("ddkaltest", when="+conformal_tracking")
 


### PR DESCRIPTION
and a new variant since building conformal tracking brings a bunch of dependencies.