### PR TITLE
Add tag for ddfastshowerml@0.2.0

### DIFF
--- a/packages/ddfastshowerml/package.py
+++ b/packages/ddfastshowerml/package.py
@@ -18,6 +18,10 @@ class Ddfastshowerml(CMakePackage, Key4hepPackage):
 
     version("main", branch="main")
     version(
+        "0.2.0",
+        sha256="1a124c9d19efe1a5435f8838a31c4d9325e23d0bab7d46603f3de654a4cfbbfd",
+    )
+    version(
         "0.1.1",
         sha256="a9628624736baea4261950615b698c9389763c18953c29bb5b1635d8d2dd9c3b",
     )


### PR DESCRIPTION
BEGINRELEASENOTES
- Add the `v0.2.0` tag for `ddfastshowerml` and make it depend on a `cxx` compiler

ENDRELEASENOTES

The `cxx` compiler is also part of #748. I am not entirely sure if it's strictly necessary (depends a bit on how far we jump with the spack commit).