### PR TITLE
Added delphes dependency (without version) for k4RecTracker PR#61

### DIFF
--- a/packages/k4rectracker/package.py
+++ b/packages/k4rectracker/package.py
@@ -32,7 +32,9 @@ class K4rectracker(CMakePackage, Key4hepPackage):
     depends_on("k4fwcore")
     depends_on("marlinutil")
     depends_on("root")
-    depends_on("delphes", when="@0.6.0:") # To be updated with specifc version once new delphes tag with latest changes is released
+    depends_on(
+        "delphes", when="@0.6.0:"
+    )  # To be updated with specifc version once new delphes tag with latest changes is released
     # This shouldn't be necessary but the debug builds are failing because lcio can't be found
     # It started happening after adding marlinutil to the dependencies
     depends_on("lcio")


### PR DESCRIPTION
BEGINRELEASENOTES
- Added a delphes dependency to k4RecTracker for [k4RecTracker pull request #61](https://github.com/key4hep/k4RecTracker/pull/61) 
  - Currently without specifying version, since [required delphes changes](https://github.com/delphes/delphes/pull/160) have not been released as new tag/release
  - To be updated in the future 

ENDRELEASENOTES

