### PR TITLE
Update the hash for kkmcee that was changed by the authors

### DIFF
--- a/packages/kkmcee/package.py
+++ b/packages/kkmcee/package.py
@@ -23,7 +23,7 @@ class Kkmcee(AutotoolsPackage):
     version("main", branch="FCC_release")
     version(
         "5.01.00",
-        sha256="7ef81f37c81efbe736651fcc2eed659da04a43e864d4d6047290ca9c65b3cad5",
+        sha256="11d80b73d7ffc4d08769c5ce55a39a96f6ac0c5a6652d87159d3398d162bd5f1",
         url="https://lcgpackages.web.cern.ch/tarFiles/sources/MCGeneratorsTarFiles/KKMCee-5.01.00.tar.gz",
     )
     version(


### PR DESCRIPTION
to include a patch:

```
Save the complete and truncated (longitudinal components) spin weights
information in the HepMC3 record as particle (Tau-, Tau+) attributes (Jim John,
2025.07.21).
```