### PR TITLE
Make k4actstracking depend on ODD for testing

### DIFF
--- a/packages/k4actstracking/package.py
+++ b/packages/k4actstracking/package.py
@@ -22,6 +22,7 @@ class K4actstracking(CMakePackage, Key4hepPackage):
     depends_on("root")
     depends_on("edm4hep")
     depends_on("k4fwcore")
+    depends_on("opendatadetector", type="test")
 
     def cmake_args(self):
         return []


### PR DESCRIPTION
BEGINRELEASENOTES
- Make k4ActsTracking depend on OpenDataDetector for testing

ENDRELEASENOTES

All currently existing tests for k4actstracking depend on the ODD
