### PR TITLE
Add a `key4hep-sim-reco` environment and build it in an image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,6 @@
 name: Build Stack and Publish Image
 description: |
-  Publish key4hep-dev-external stack docker image.
+  Publish key4hep-dev-external stack and key4hep-sim-reco docker images.
   This workflow relies on a spack cache.
 
 on: push
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-image:
+  build-externals-image:
     uses: ./.github/workflows/image-template.yaml
     strategy:
       fail-fast: false
@@ -20,3 +20,13 @@ jobs:
       os: ${{ matrix.os }}
       registry: ghcr.io
       stack: externals
+
+  build-sim-reco-image:
+    uses: ./.github/workflows/image-template.yaml
+    strategy:
+      fail-fast: false
+    needs: build-externals-image
+    with:
+      os: ubuntu24
+      registry: ghcr.io
+      stack: sim-reco

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,3 +19,4 @@ jobs:
     with:
       os: ${{ matrix.os }}
       registry: ghcr.io
+      stack: externals

--- a/.github/workflows/docker-build-push-template.yaml
+++ b/.github/workflows/docker-build-push-template.yaml
@@ -17,6 +17,9 @@ on:
       registry:
         required: true
         type: string
+      stack:
+        required: true
+        type: string
     outputs:
       image-uri:
         description: "The URI of the built image with digest"
@@ -32,7 +35,7 @@ jobs:
   build-and-push:
     runs-on: ${{ inputs.runner }}
     outputs:
-      image-uri: ${{ inputs.registry }}/${{ github.repository_owner }}/key4hep-externals-${{ inputs.os }}:${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}-${{ inputs.platform }}@${{ steps.build.outputs.digest }}
+      image-uri: ${{ inputs.registry }}/${{ github.repository_owner }}/key4hep-${{ inputs.stack }}-${{ inputs.os }}:${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}-${{ inputs.platform }}@${{ steps.build.outputs.digest }}
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: endersonmenezes/free-disk-space@v2
@@ -62,7 +65,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ inputs.registry }}/${{ github.repository_owner }}/key4hep-externals-${{ inputs.os }}
+          images: ${{ inputs.registry }}/${{ github.repository_owner }}/key4hep-${{ inputs.stack }}-${{ inputs.os }}
           flavor: latest=false,suffix=-${{ inputs.platform }}
       - name: Determine spack ref
         id: getref
@@ -76,7 +79,7 @@ jobs:
           push: true
           platforms: linux/${{ inputs.platform }}
           context: ./Docker/${{inputs.os}}
-          file: ./Docker/${{inputs.os}}/Dockerfile-externals
+          file: ./Docker/${{inputs.os}}/Dockerfile-${{ inputs.stack }}
           build-args: |
             GITHUB_REPOSITORY=${{ github.repository }}
             COMMIT_SHA=${{ github.sha }}

--- a/.github/workflows/image-template.yaml
+++ b/.github/workflows/image-template.yaml
@@ -1,6 +1,6 @@
-name: Publish key4hep-externals image
+name: Publish key4hep images
 description: |
-  Loads a key4hep-dev-external stack from spack cache.
+  Loads a key4hep stack from spack cache.
   This workflow builds the image and pushes it to the registry.
 
 on:
@@ -12,6 +12,10 @@ on:
       registry:
         required: true
         type: string
+      stack:
+        required: true
+        type: string
+
 
 permissions:
   contents: read
@@ -27,6 +31,7 @@ jobs:
       runner: ubuntu-latest
       platform: amd64
       registry: ${{ inputs.registry }}
+      stack: ${{ inputs.stack }}
 
   build-linux-arm64:
     uses: ./.github/workflows/docker-build-push-template.yaml
@@ -35,6 +40,7 @@ jobs:
       runner: ubuntu-24.04-arm
       platform: arm64
       registry: ${{ inputs.registry }}
+      stack: ${{ inputs.stack }}
 
   publish-multiarch:
     needs:
@@ -52,7 +58,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ inputs.registry }}/${{ github.repository_owner }}/key4hep-externals-${{ inputs.os }}
+          images: ${{ inputs.registry }}/${{ github.repository_owner }}/key4hep-${{ inputs.stack }}-${{ inputs.os }}
           flavor: latest=${{ github.ref == 'refs/heads/main' }}
       - name: Create manifest
         id: build

--- a/Docker/ubuntu24/Dockerfile-sim-reco
+++ b/Docker/ubuntu24/Dockerfile-sim-reco
@@ -1,4 +1,4 @@
-FROM ghcr.io/key4hep/key4hep-externals-ubuntu24:latest
+FROM ghcr.io/key4hep/key4hep-externals-ubuntu24:reco-image
 
 # Configure spack environment with:
 # - System compilers

--- a/Docker/ubuntu24/Dockerfile-sim-reco
+++ b/Docker/ubuntu24/Dockerfile-sim-reco
@@ -7,8 +7,6 @@ ENV SPACK_COLOR="always"
 ARG SPACK_BUILDCACHE
 ARG OCI_USERNAME
 RUN . /opt/setup_spack.sh && \
-    spack config add 'config:install_tree:padded_length:128' && \
-    spack compiler find && \
     if [ -n "${SPACK_BUILDCACHE}" ]; then \
         spack mirror remove local-buildcache || true; \
         spack mirror add --oci-username "${OCI_USERNAME}" --oci-password-variable OCI_PASSWORD --unsigned --autopush local-buildcache "${SPACK_BUILDCACHE}";\

--- a/Docker/ubuntu24/Dockerfile-sim-reco
+++ b/Docker/ubuntu24/Dockerfile-sim-reco
@@ -1,5 +1,19 @@
 FROM ghcr.io/key4hep/key4hep-externals-ubuntu24:latest
 
+# Configure spack environment with:
+# - System compilers
+# - Buildcache
+ENV SPACK_COLOR="always"
+ARG SPACK_BUILDCACHE
+ARG OCI_USERNAME
+RUN . /opt/setup_spack.sh && \
+    spack config add 'config:install_tree:padded_length:128' && \
+    spack compiler find && \
+    if [ -n "${SPACK_BUILDCACHE}" ]; then \
+        spack mirror remove local-buildcache || true; \
+        spack mirror add --oci-username "${OCI_USERNAME}" --oci-password-variable OCI_PASSWORD --unsigned --autopush local-buildcache "${SPACK_BUILDCACHE}";\
+    fi
+
 # Create the environment setup script
 RUN . /opt/setup_spack.sh && \
     echo ". /opt/setup_spack.sh" > ${HOME}/setup_env.sh && \
@@ -8,13 +22,17 @@ RUN . /opt/setup_spack.sh && \
     echo "spack env status" >> ${HOME}/setup_env.sh
 
 # Concretize the stack
-RUN . ${HOME}/setup_env.sh && \
-    spack concretize --reuse
+RUN --mount=type=secret,id=ocipass \
+    . ${HOME}/setup_env.sh && \
+    OCI_PASSWORD=$(cat /run/secrets/ocipass) spack concretize --reuse
 
 # Installing fragments of dependency tree in separate layers for cached debugging
 ENV SPACK_INSTALL_OPTS="--only-concrete --no-add --fail-fast"
 
-RUN . ${HOME}/setup_env.sh && \
-    spack spec -NIt && \
-    spack install ${SPACK_INSTALL_OPTS} && \
-    spack clean -a
+RUN --mount=type=secret,id=ocipass \
+    . ${HOME}/setup_env.sh && \
+    OCI_PASSWORD=$(cat /run/secrets/ocipass) spack spec -NIt && \
+    OCI_PASSWORD=$(cat /run/secrets/ocipass) spack install ${SPACK_INSTALL_OPTS} && \
+    spack env deactivate && \
+    spack clean -a && \
+    spack mirror rm local-buildcache

--- a/Docker/ubuntu24/Dockerfile-sim-reco
+++ b/Docker/ubuntu24/Dockerfile-sim-reco
@@ -34,3 +34,10 @@ RUN --mount=type=secret,id=ocipass \
     spack env deactivate && \
     spack clean -a && \
     spack mirror rm local-buildcache
+
+COPY utilities.sh /opt/scripts/utilities.sh
+
+RUN . ${HOME}/setup_env.sh && \
+    KEY4HEP_STACK_PATH=$(spack find --format "{prefix}" key4hep-stack) && \
+    echo "source $(echo ${KEY4HEP_STACK_PATH} | sed -E 's/\x1b\[[0-9;]*m//g')/setup.sh" > /opt/setup_key4hep.sh && \
+    echo "source /opt/scripts/utilities.sh" >> /opt/setup_key4hep.sh

--- a/Docker/ubuntu24/Dockerfile-sim-reco
+++ b/Docker/ubuntu24/Dockerfile-sim-reco
@@ -1,0 +1,19 @@
+FROM ghcr.io/key4hep/key4hep-externals-ubuntu24:latest
+
+# Create the environment setup script
+RUN echo ". /opt/setup_spack.sh" > ${HOME}/setup_env.sh && \
+    echo "cd ${SPACK_ROOT}/var/key4hep-spack/environments/key4hep-sim-reco" >> ${HOME}/setup_env.sh && \
+    echo "spack env activate ." >> ${HOME}/setup_env.sh && \
+    echo "spack env status" >> ${HOME}/setup_env.sh
+
+# Concretize the stack
+RUN . ${HOME}/setup_env.sh && \
+    spack concretize --reuse
+
+# Installing fragments of dependency tree in separate layers for cached debugging
+ENV SPACK_INSTALL_OPTS="--only-concrete --no-add --fail-fast"
+
+RUN . ${HOME}/setup_env.sh && \
+    spack spec -NIt && \
+    spack install ${SPACK_INSTALL_OPTS} && \
+    spack clean -a

--- a/Docker/ubuntu24/Dockerfile-sim-reco
+++ b/Docker/ubuntu24/Dockerfile-sim-reco
@@ -1,7 +1,8 @@
 FROM ghcr.io/key4hep/key4hep-externals-ubuntu24:latest
 
 # Create the environment setup script
-RUN echo ". /opt/setup_spack.sh" > ${HOME}/setup_env.sh && \
+RUN . /opt/setup_spack.sh && \
+    echo ". /opt/setup_spack.sh" > ${HOME}/setup_env.sh && \
     echo "cd ${SPACK_ROOT}/var/key4hep-spack/environments/key4hep-sim-reco" >> ${HOME}/setup_env.sh && \
     echo "spack env activate ." >> ${HOME}/setup_env.sh && \
     echo "spack env status" >> ${HOME}/setup_env.sh

--- a/Docker/ubuntu24/utilities.sh
+++ b/Docker/ubuntu24/utilities.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+_replace_marlin_dll() {
+    # replace the library on MARLIN_DLL with the local one (if any)
+    local pkg_name=${1}
+    local install_prefix=${2}
+    if echo ${MARLIN_DLL} | grep -qE "/${pkg_name}/"; then
+        local old_lib=$(echo ${MARLIN_DLL} | tr ":" "\n" | grep -E "/${pkg_name}/")
+        local lib_name=$(basename ${old_lib})
+        local new_lib=$(pwd)/${install_prefix}/lib/${lib_name}
+        export MARLIN_DLL=$(echo ${MARLIN_DLL%:} | tr ":" "\n" | grep -Ev "/${pkg_name}/" | tr "\n" ":")${new_lib}
+        echo "Replaced library on MARLIN_DLL: old: '${old_lib}'"
+        echo "                                new: '${new_lib}'"
+    fi
+}
+
+k4_local_repo() {
+    for arg in "$@"; do
+        case $arg in
+            -h|--help)
+                echo "Usage: k4_local_repo [install]"
+                echo "       install : the directory where the software is installed (default: ./install)"
+                echo "       -h      : print this help message"
+                echo "Run the function from the directory where the repository is located."
+                return 0
+                ;;
+            *)
+                ;;
+        esac
+    done
+
+    if [ -n "$1" ]; then
+        install=$1
+    else
+        install=install
+    fi
+    current_repo=$(basename $PWD | tr '[:upper:]' '[:lower:]' | tr -d -)
+    export PATH=$(echo $PATH | tr ":" "\n" | grep -Ev "/${current_repo}/" | tr "\n" ":")
+    export ROOT_LIBRARY_PATH=$(echo $ROOT_LIBRARY_PATH | tr ":" "\n" | grep -Ev "/${current_repo}/" | tr "\n" ":")
+    export LD_LIBRARY_PATH=$(echo $LD_LIBRARY_PATH | tr ":" "\n" | grep -Ev "/${current_repo}/" | tr "\n" ":")
+    export PYTHONPATH=$(echo $PYTHONPATH | tr ":" "\n" | grep -Ev "/${current_repo}/" | tr "\n" ":")
+    export CMAKE_PREFIX_PATH=$(echo $CMAKE_PREFIX_PATH | tr ":" "\n" | grep -Ev "/${current_repo}/" | tr "\n" ":")
+    export PKG_CONFIG_PATH=$(echo $PKG_CONFIG_PATH | tr ":" "\n" | grep -Ev "/${current_repo}/" | tr "\n" ":")
+    export ROOT_INCLUDE_PATH=$(echo $ROOT_INCLUDE_PATH | tr ":" "\n" | grep -Ev "/${current_repo}/" | tr "\n" ":")
+    _replace_marlin_dll ${current_repo} ${install}
+    export PATH=$PWD/$install/bin:$PATH
+    export ROOT_LIBRARY_PATH=$PWD/$install/lib:$PWD/$install/lib64:$ROOT_LIBRARY_PATH
+    export LD_LIBRARY_PATH=$PWD/$install/lib:$PWD/$install/lib64:$LD_LIBRARY_PATH
+    # Get the python site-packages directory
+    libpythondir=$(python -c "import site; print('/'.join(site.getsitepackages()[0].split('/')[-3:]))")
+    export PYTHONPATH=$PWD/$install/python:$PWD/$install/$libpythondir:$PYTHONPATH
+    export PYTHONPATH=$PWD/$install/python:$PYTHONPATH
+    export CMAKE_PREFIX_PATH=$PWD/$install:$CMAKE_PREFIX_PATH
+    export PKG_CONFIG_PATH=$PWD/$install/lib/pkgconfig:$PKG_CONFIG_PATH
+    export ROOT_INCLUDE_PATH=$PWD/$install/include:$ROOT_INCLUDE_PATH
+    if [ "$current_repo" = "k4geo" ]; then
+        export LCGEO=$PWD
+        export K4GEO=$PWD
+        export lcgeo_DIR=$PWD
+        export k4geo_DIR=$PWD
+        echo "Added LCGEO, K4GEO, lcgeo_DIR and k4geo_DIR to the environment"
+    fi
+    echo "Added $PWD/$install to the environment and removed any paths containing /${current_repo}/"
+    echo "Some variables may have to be updated manually to point to the local installation"
+}
+
+export -f k4_local_repo
+export -f _replace_marlin_dll

--- a/environments/key4hep-common/packages.yaml
+++ b/environments/key4hep-common/packages.yaml
@@ -143,7 +143,7 @@ packages:
   # Since many packages depend on setuptools that was dropped in 3.12,
   # without asking explicitly the version used will be 3.11
   python:
-    require: "@3.12: +optimizations"
+    require: "@3.12:3.13 +optimizations"
   sio:
     variants: cxxstd=20
 

--- a/environments/key4hep-dev-external/spack.yaml
+++ b/environments/key4hep-dev-external/spack.yaml
@@ -12,6 +12,9 @@ spack:
     fmt:
       require: "@:10"
 
+    py-numpy:
+      require: "@2: ^openblas"
+
   concretizer:
     targets:
       host_compatible: true

--- a/environments/key4hep-sim-reco/spack.yaml
+++ b/environments/key4hep-sim-reco/spack.yaml
@@ -1,0 +1,14 @@
+spack:
+  include:
+    - ../key4hep-common-opt/packages.yaml
+    - ../key4hep-common/packages.yaml
+
+  view: false
+
+  concretizer:
+    unify: true
+    targets:
+      host_compatible: true
+
+  specs:
+    - key4hep-stack +analysis~generators~ml~devtools

--- a/environments/key4hep-sim-reco/spack.yaml
+++ b/environments/key4hep-sim-reco/spack.yaml
@@ -1,6 +1,5 @@
 spack:
   include:
-    - ../key4hep-common-opt/packages.yaml
     - ../key4hep-common/packages.yaml
 
   view: false


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a `key4hep-sim-reco` environment that skips building all generators and most of the machine learning adjacent tools
- Add a CI workflow that builds this environment into an ubuntu24 based image

ENDRELEASENOTES

- [x] Includes #791 
- [x] Includes #793 
- [x] Includes #792 
- [x] Make `sim-reco` image depend on `dev-externals` image in one workflow (currently not done for quicker turnaround on development)
- [ ] Check whether `dev-externals` packages are properly re-used here to avoid having duplicated packages in the image
- [x] Check ifthe whole image can be built within the 6 hours we have from github -> **They cannot without at least parts of it being available from a buildcache**.
- [x] Includes some parts of #795 
- [x] Remove the arm build for now, as that will probably take some time to fix, since at least one package is not compatible with arm: see also https://github.com/spack/spack-packages/pull/1714

~ARM image for `sim-reco` is not working because `simsipm` relies on x86 intrinsice (at least on header), see e.g.: https://github.com/key4hep/key4hep-spack/actions/runs/17981415816/job/51148208590#step:8:1742~