### PR TITLE
Add the latest tag for several iLCSoft packages

### DIFF
--- a/packages/ced/package.py
+++ b/packages/ced/package.py
@@ -18,6 +18,10 @@ class Ced(CMakePackage, Ilcsoftpackage):
 
     version("master", branch="master")
     version(
+        "1.10.1",
+        sha256="be78f0e84de7822997525fb7d823a24225b6023f87a6a9c32b6cf14a2f65336c",
+    )
+    version(
         "1.10",
         sha256="c3c6540559c00d55bd5981816d39290dbb9b091e34673e301e42934988a74012",
     )

--- a/packages/cedviewer/package.py
+++ b/packages/cedviewer/package.py
@@ -18,6 +18,10 @@ class Cedviewer(CMakePackage, Ilcsoftpackage):
 
     version("master", branch="master")
     version(
+        "1.21",
+        sha256="3a3326f2277b2de8c0eda8fc47f8f0d9e0d9fd2dfb920ddeda480bc4ca8a6140",
+    )
+    version(
         "1.20",
         sha256="e2b1b50b42be28aa28bbdba99e403e053a1aff7bcd7c76c6b7224768a3d28c68",
     )

--- a/packages/conformaltracking/package.py
+++ b/packages/conformaltracking/package.py
@@ -20,6 +20,10 @@ class Conformaltracking(CMakePackage, Ilcsoftpackage):
 
     version("master", branch="master")
     version(
+        "1.12.1",
+        sha256="50809b288e0af6af40ffd3257803a0413454c277647bd748d867312afeff9d8e",
+    )
+    version(
         "1.12",
         sha256="e586bbae21e49a69797109dd9db267812e9ded1cd98877f245972a329cea9cc5",
     )

--- a/packages/ddmarlinpandora/package.py
+++ b/packages/ddmarlinpandora/package.py
@@ -18,6 +18,10 @@ class Ddmarlinpandora(CMakePackage, Ilcsoftpackage):
 
     version("master", branch="master")
     version(
+        "0.14",
+        sha256="b22f1fb589d59b9878d746632ad74ca76a03153b16c8901023eecc7469f6dbdb",
+    )
+    version(
         "0.13",
         sha256="80274bba9bc4ce53f0d78132bd5aba82f03000a527c2eed3adc5c33f12d194f3",
     )
@@ -38,7 +42,7 @@ class Ddmarlinpandora(CMakePackage, Ilcsoftpackage):
         sha256="92410186209508091e0a8e330986283ffb32e40fd7195d10aad1a6a2e953f3ee",
     )
 
-    depends_on("c", type="build")
+    depends_on("c", type="build", when="@:0.13")
     depends_on("cxx", type="build")
 
     depends_on("ilcutil")

--- a/packages/gear/package.py
+++ b/packages/gear/package.py
@@ -19,6 +19,10 @@ class Gear(CMakePackage, Ilcsoftpackage):
     version("master", branch="master")
 
     version(
+        "1.9.6",
+        sha256="9089dd88b29c63725c6f46551d3bcf9810e0d400f3b402ba1e86ff9bcb08c66e",
+    )
+    version(
         "1.9.5",
         sha256="9e7c70b2dd83c84e88c9a124808588c1ca91c66fcc0385de9d33b584e813a2ed",
     )
@@ -50,6 +54,7 @@ class Gear(CMakePackage, Ilcsoftpackage):
     variant("doc", default=False, description="build doxygen documentation")
 
     depends_on("cxx", type="build")
+    depends_on("c", type="build", when="@:1.9.4")
 
     depends_on("ilcutil")
     depends_on("clhep")

--- a/packages/marlin/package.py
+++ b/packages/marlin/package.py
@@ -19,6 +19,10 @@ class Marlin(CMakePackage, Ilcsoftpackage):
     version("master", branch="master")
 
     version(
+        "1.19.6",
+        sha256="744deba7f8e0c6c5e1554ea53a53ef7ad9973a4c1ae2e7b164efb4d9a4eba8fb",
+    )
+    version(
         "1.19.5",
         sha256="d0ad571fa7f47badf874bd577f644686ad85175c622a7d9797501bdfa5ea93f6",
     )
@@ -62,6 +66,7 @@ class Marlin(CMakePackage, Ilcsoftpackage):
     variant("doc", default=False, description="build doxygen documentation")
 
     depends_on("cxx", type="build")
+    depends_on("c", type="build", when="@:1.19.4")
 
     depends_on("ilcutil")
     depends_on("gear")

--- a/packages/marlinreco/package.py
+++ b/packages/marlinreco/package.py
@@ -18,6 +18,10 @@ class Marlinreco(CMakePackage, Ilcsoftpackage):
 
     version("master", branch="master")
     version(
+        "1.37",
+        sha256="19f11b1e54514c678c06fffe4fea07e2112f4a92cff6b3b53c70ccb308616555",
+    )
+    version(
         "1.36.2",
         sha256="3d147297f03c9d02fcbf441f895f82185bc7607eef59fb119e2268a521a811c7",
     )

--- a/packages/marlintrkprocessors/package.py
+++ b/packages/marlintrkprocessors/package.py
@@ -18,6 +18,10 @@ class Marlintrkprocessors(CMakePackage, Ilcsoftpackage):
 
     version("master", branch="master")
     version(
+        "2.12.8",
+        sha256="5108c4219f7e10a7062371299eb8c0d9202cf2e9d7a02893d779d32b91b11f10",
+    )
+    version(
         "2.12.7",
         sha256="34cc4cfbf6265fbd9c1164a294957596a5cd722d82d9e66a3f8db51414fa8271",
     )


### PR DESCRIPTION
Also make sure that the depends_on("c") is set correctly for older versions where it has not been fixed yet