### PR TITLE
Use correct package hash for ddmarlinpandora

### DIFF
--- a/packages/ddmarlinpandora/package.py
+++ b/packages/ddmarlinpandora/package.py
@@ -19,7 +19,7 @@ class Ddmarlinpandora(CMakePackage, Ilcsoftpackage):
     version("master", branch="master")
     version(
         "0.14",
-        sha256="b22f1fb589d59b9878d746632ad74ca76a03153b16c8901023eecc7469f6dbdb",
+        sha256="9c8de305d65007e2ce22489f961e469111d24b1c850dac5efc237019bd4da28e",
     )
     version(
         "0.13",


### PR DESCRIPTION
BEGINRELEASENOTES
- fix the hash for the latest ddmarlinpandora tag

ENDRELEASENOTES

Not sure why this changed from #804, but checksumming this via spack now yiels

```console
$ spack checksum ddmarlinpandora 0.14
==> Found 1 version of ddmarlinpandora
==> Fetching https://github.com/iLCSoft/DDMarlinPandora/archive/v00-14.tar.gz
    [100%]  103.67 KB @    2.4 MB/s

    version("0.14", sha256="9c8de305d65007e2ce22489f961e469111d24b1c850dac5efc237019bd4da28e")

```