### PR TITLE
reset `GAUDI_PLUGIN_PATH` in `k4_local_repo`

### DIFF
--- a/scripts/cvmfs/setup-nightlies.sh
+++ b/scripts/cvmfs/setup-nightlies.sh
@@ -168,7 +168,7 @@ k4_local_repo() {
     export CMAKE_PREFIX_PATH=$PWD/$install:$CMAKE_PREFIX_PATH
     export PKG_CONFIG_PATH=$PWD/$install/lib/pkgconfig:$PKG_CONFIG_PATH
     export ROOT_INCLUDE_PATH=$PWD/$install/include:$ROOT_INCLUDE_PATH
-    export GAUDI_PLUGIN_PATH=$PWD/$install/lib:$GAUDI_PLUGIN_PATH
+    export GAUDI_PLUGIN_PATH=$PWD/$install/lib:$PWD/$install/lib64:$GAUDI_PLUGIN_PATH
     if [ "$current_repo" = "k4geo" ]; then
         export LCGEO=$PWD
         export K4GEO=$PWD

--- a/scripts/cvmfs/setup-releases.sh
+++ b/scripts/cvmfs/setup-releases.sh
@@ -163,7 +163,7 @@ k4_local_repo() {
     export CMAKE_PREFIX_PATH=$PWD/$install:$CMAKE_PREFIX_PATH
     export PKG_CONFIG_PATH=$PWD/$install/lib/pkgconfig:$PKG_CONFIG_PATH
     export ROOT_INCLUDE_PATH=$PWD/$install/include:$ROOT_INCLUDE_PATH
-    export GAUDI_PLUGIN_PATH=$PWD/$install/lib:$GAUDI_PLUGIN_PATH
+    export GAUDI_PLUGIN_PATH=$PWD/$install/lib:$PWD/$install/lib64:$GAUDI_PLUGIN_PATH
     if [ "$current_repo" = "k4geo" ]; then
         export LCGEO=$PWD
         export K4GEO=$PWD


### PR DESCRIPTION
BEGINRELEASENOTES
- Reset `GAUDI_PLUGIN_PATH` in `k4_local_repo`

ENDRELEASENOTES

Developing Gaudi with `k4_local_repo` keeps the `GAUDI_PLUGIN_PATH` which results in errors like this when wrong version of library is linked.

```
[ 59%] Linking CXX shared module libGaudiCoreSvc.so
dlopen failed for /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2025-09-21/x86_64-almalinux9-gcc14.2.0-opt/gaudi/40.0-hqgvjz/lib/libGaudiCoreSvc.so
WARNING: cannot load /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2025-09-21/x86_64-almalinux9-gcc14.2.0-opt/gaudi/40.0-hqgvjz/lib/libGaudiCoreSvc.so
WARNING: /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2025-09-21/x86_64-almalinux9-gcc14.2.0-opt/gaudi/40.0-hqgvjz/lib/libGaudiCoreSvc.so: undefined symbol: _ZN7AlgTool14queryInterfaceERK11InterfaceIDPPv
dlopen failed for /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2025-09-21/x86_64-almalinux9-gcc14.2.0-opt/gaudi/40.0-hqgvjz/lib/libGaudiCoreSvc.so
WARNING: cannot load /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2025-09-21/x86_64-almalinux9-gcc14.2.0-opt/gaudi/40.0-hqgvjz/lib/libGaudiCoreSvc.so
WARNING: /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2025-09-21/x86_64-almalinux9-gcc14.2.0-opt/gaudi/40.0-hqgvjz/lib/libGaudiCoreSvc.so: undefined symbol: _ZN7AlgTool14queryInterfaceERK11InterfaceIDPPv
dlopen failed for /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2025-09-21/x86_64-almalinux9-gcc14.2.0-opt/gaudi/40.0-hqgvjz/lib/libGaudiCoreSvc.so
WARNING: cannot load /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2025-09-21/x86_64-almalinux9-gcc14.2.0-opt/gaudi/40.0-hqgvjz/lib/libGaudiCoreSvc.so
WARNING: /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2025-09-21/x86_64-almalinux9-gcc14.2.0-opt/gaudi/40.0-hqgvjz/lib/libGaudiCoreSvc.so: undefined symbol: _ZN7AlgTool14queryInterfaceERK11InterfaceIDPPv
```
This is especially annoying for builds with different Gaudi version that would otherwise work fine.

Resetting `GAUDI_PLUGIN_PATH` like the other env variables solves the issue. Unsetting it also works in this case but perhaps we'd like to keep the variable