### PR TITLE
Make sure that k4actstracking is on the runtime env

### DIFF
--- a/packages/k4actstracking/package.py
+++ b/packages/k4actstracking/package.py
@@ -32,4 +32,4 @@ class K4actstracking(CMakePackage, Key4hepPackage):
 
     def setup_run_environment(self, env):
         env.prepend_path("PYTHONPATH", self.prefix.python)
-        env.prepend_path("LD_LIBRARY_PATH", self.spec["k4actstracking"].prefix.lib)
+        env.prepend_path("GAUDI_PLUGIN_PATH", self.spec["k4actstracking"].prefix.lib)


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure that components from `k4ActsTracking` are available at runtime

ENDRELEASENOTES
