### PR TITLE
Add pyarrow to the stack

### DIFF
--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -166,6 +166,7 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
             depends_on("py-matplotlib")
             depends_on("py-nbconvert")
             depends_on("py-vector")
+            depends_on("py-pyarrow")
 
     for v in ("+ml", "+full"):
         with when(v):


### PR DESCRIPTION
BEGINRELEASENOTES

- Added [pyarrow](https://pypi.org/project/pyarrow/)

ENDRELEASENOTES

This package is required, e.g. to create parquet files from awkward arrays.

```python
import awkward as ak
ak.to_parquet(ak.Array([1,2,3,4,5]), "new.parquet")
```

This is currently used in @doloresgarcia MLPF studies for CLD and ALLEGRO for dataset creation, and at the moment this step requires loading completely independent from key4hep environment.