### PR TITLE
Require arrow with parquet

### DIFF
--- a/environments/key4hep-common/packages.yaml
+++ b/environments/key4hep-common/packages.yaml
@@ -8,6 +8,8 @@ packages:
     require: +dd4hep cxxstd=20 +json
   # Build the assembler since the one from Alma 9 is old
   # and does not support AVX2 from py-onnxruntime or py-torch
+  arrow:
+    require: +parquet
   binutils:
     require: +gas
   boost:


### PR DESCRIPTION
needed to have the python bindings support parquet. See https://github.com/key4hep/key4hep-spack/pull/824