### PR TITLE
Require +zstd for arrow

### DIFF
--- a/environments/key4hep-common/packages.yaml
+++ b/environments/key4hep-common/packages.yaml
@@ -9,7 +9,7 @@ packages:
   # Build the assembler since the one from Alma 9 is old
   # and does not support AVX2 from py-onnxruntime or py-torch
   arrow:
-    require: +parquet
+    require: +parquet+zstd
   binutils:
     require: +gas
   boost:


### PR DESCRIPTION
fixes writing awkward arrays to parquet when parquet is enabled. See https://github.com/key4hep/key4hep-spack/pull/824