### PR TITLE
Make extra_rpaths be inside extra_attributes for a newer Spack

### DIFF
--- a/environments/key4hep-common/compilers.yaml
+++ b/environments/key4hep-common/compilers.yaml
@@ -17,4 +17,4 @@ packages:
           c: /usr/bin/gcc
           cxx: /usr/bin/g++
           fortran: /usr/bin/gfortran
-      extra_rpaths: []
+        extra_rpaths: []


### PR DESCRIPTION
This is needed to even activate an environment with the most recent Spack. The documentation explicitly says they have to be inside extra_attributes here: https://github.com/spack/spack/blob/742dbe9bdccf3b66e9b6bde802fc38e357155fdf/lib/spack/docs/packages_yaml.rst?plain=1#L359
and this is the error I get when doing `spacktivate` (it can be seen in CI):

```
==> Error: /key4hep-spack/environments/key4hep-common/compilers.yaml:13: Additional properties are not allowed ('extra_rpaths' was unexpected)
```