### PR TITLE
Add a switch `--lcg` to use the LCG stack with the nightlies

### DIFF
--- a/scripts/cvmfs/setup-nightlies.sh
+++ b/scripts/cvmfs/setup-nightlies.sh
@@ -145,6 +145,12 @@ k4_local_repo() {
         esac
     done
 
+    # if lcg
+    if [ $lcg_setup -eq 1 ]; then
+        echo "With LCG views, k4_local_repo won't remove paths to the current repository in the stack"
+        echo "The version in the stack will be always findable. It's possible that this causes issue, please report them"
+    fi
+
     if [ -n "$1" ]; then
         install=$1
     else


### PR DESCRIPTION
Instead of having to source some other path, this provides quick access. Incompatible with most of the options for now.
Run 
``` bash
source /cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh --lcg
```