### PR TITLE
hep-flare: add `git` so `branch="main"` makes sense

### DIFF
--- a/packages/hep-flare/package.py
+++ b/packages/hep-flare/package.py
@@ -15,6 +15,7 @@ class HepFlare(PythonPackage):
 
     homepage = "https://github.com/CamCoop1/FLARE"
     pypi = "hep-flare/hep-flare-0.1.11.tar.gz"
+    git = "https://github.com/CamCoop1/FLARE.git"
 
     license("MIT")
 


### PR DESCRIPTION
`hep-flare` currently fails audits with:
```
==> Error: hep-flare version 'master' has extra arguments: 'branch'
Valid arguments for a url fetcher are: 
    'url', 'sha256', 'md5', 'sha1', 'sha224', 'sha384', 'sha512', and 'checksum'
```

BEGINRELEASENOTES
- hep-flare: add `git` so `branch="main"` makes sense

ENDRELEASENOTES
