### PR TITLE
k4fwcore: pass spack audit

### DIFF
--- a/packages/k4fwcore/package.py
+++ b/packages/k4fwcore/package.py
@@ -55,7 +55,7 @@ class K4fwcore(CMakePackage, Ilcsoftpackage):
         "podio@1.3:", when="@1.3:"
     )  # using edm4hep::edm4hepDataTypes and related
     depends_on("edm4hep")
-    depends_on("edm4hep@0.10.2:", when="@1.0pre17:")
+    depends_on("edm4hep@0.10.2:")
     depends_on("edm4hep@0.99:", when="@1.2:")
 
     def cmake_args(self):


### PR DESCRIPTION
Since podio before 0.99 was removed in spack-packages, the versions up to and include 1.0pre17 are unsatisfiable.

The gaudi dependency fails audit since it is self-referential, so it is rewritten as a conflict here.

BEGINRELEASENOTES
- k4fwcore: pass spack audit

ENDRELEASENOTES
