### PR TITLE
k4actstracking: don't depend on acts +tgeo

### DIFF
--- a/packages/k4actstracking/package.py
+++ b/packages/k4actstracking/package.py
@@ -1,4 +1,4 @@
-json spack.package import *
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 


### PR DESCRIPTION
`k4actstracking` has never explicitly depended on Acts::TGeoPlugin, which was renamed to RootPlugin in https://github.com/acts-project/acts/pull/4352, and https://github.com/spack/spack-packages/pull/2587. This PR removes the variant which prevents concretization with `acts@45:`.

BEGINRELEASENOTES
- k4actstracking: don't depend on acts +tgeo

ENDRELEASENOTES
