### PR TITLE
Add variant to control download of STL files

### DIFF
--- a/packages/k4geo/package.py
+++ b/packages/k4geo/package.py
@@ -77,7 +77,9 @@ class K4geo(CMakePackage):
         )
         args.append(self.define_from_variant("INSTALL_COMPACT_FILES", "compact"))
         # The beampipe STL files are downloaded from the network at configure time
-        args.append(self.define_from_variant("INSTALL_BEAMPIPE_STL_FILES", "beampipe_stl"))
+        args.append(
+            self.define_from_variant("INSTALL_BEAMPIPE_STL_FILES", "beampipe_stl")
+        )
         args.append(self.define("BUILD_TESTING", self.run_tests))
         return args
 

--- a/packages/k4geo/package.py
+++ b/packages/k4geo/package.py
@@ -76,8 +76,7 @@ class K4geo(CMakePackage):
             f"-DCMAKE_CXX_STANDARD={self.spec['root'].variants['cxxstd'].value}"
         )
         args.append(self.define_from_variant("INSTALL_COMPACT_FILES", "compact"))
-        # The beampipe STL files are downloaded from the network at configure
-        # time, so this variant lets consumers opt out.
+        # The beampipe STL files are downloaded from the network at configure time
         args.append(self.define_from_variant("INSTALL_BEAMPIPE_STL_FILES", "beampipe_stl"))
         args.append(self.define("BUILD_TESTING", self.run_tests))
         return args

--- a/packages/k4geo/package.py
+++ b/packages/k4geo/package.py
@@ -54,6 +54,11 @@ class K4geo(CMakePackage):
     )
 
     variant("compact", default=True, description="Install compact files")
+    variant(
+        "beampipe_stl",
+        default=True,
+        description="Download and install the FCC-ee MDI beampipe CAD (STL) files",
+    )
 
     depends_on("cxx", type="build")
 
@@ -71,12 +76,9 @@ class K4geo(CMakePackage):
             f"-DCMAKE_CXX_STANDARD={self.spec['root'].variants['cxxstd'].value}"
         )
         args.append(self.define_from_variant("INSTALL_COMPACT_FILES", "compact"))
-        # Automatically install the CAD beampipe files if we install the compact files
-        args.append(
-            self.define(
-                "INSTALL_BEAMPIPE_STL_FILES", self.spec.variants["compact"].value
-            )
-        )
+        # The beampipe STL files are downloaded from the network at configure
+        # time, so this variant lets consumers opt out.
+        args.append(self.define_from_variant("INSTALL_BEAMPIPE_STL_FILES", "beampipe_stl"))
         args.append(self.define("BUILD_TESTING", self.run_tests))
         return args
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Added a variant to control the cmakefile argument for FCC-ee beampipe installation at configure time
ENDRELEASENOTES

This PR lets consumers opt out of downloading the FCC-ee beampipe files via the spack recipe