### PR TITLE
Allow skipping connection errors in CI

### DIFF
--- a/.github/workflows/concretize-current-nightly.yaml
+++ b/.github/workflows/concretize-current-nightly.yaml
@@ -78,7 +78,7 @@ jobs:
                 env=key4hep-release
             elif [ "${{ matrix.build_type }}" = "nightly" ]; then
                 env=key4hep-nightly-opt
-                python3 /key4hep-spack/scripts/fetch_nightly_versions.py --path /key4hep-spack/environments/key4hep-common/packages.yaml --extra-path /key4hep-spack/environments/key4hep-common-opt/packages.yaml ""
+                python3 /key4hep-spack/scripts/fetch_nightly_versions.py --path /key4hep-spack/environments/key4hep-common/packages.yaml --extra-path /key4hep-spack/environments/key4hep-common-opt/packages.yaml --skip-connection-errors ""
             else
                 echo "Unknown build type"
                 exit 1

--- a/.github/workflows/concretize.yaml
+++ b/.github/workflows/concretize.yaml
@@ -64,7 +64,7 @@ jobs:
                 env=key4hep-release-opt
             elif [ "${{ matrix.build_type }}" = "nightly" ]; then
                 env=key4hep-nightly-opt
-                python3 /key4hep-spack/scripts/fetch_nightly_versions.py --path /key4hep-spack/environments/key4hep-common/packages.yaml --extra-path /key4hep-spack/environments/key4hep-common-opt/packages.yaml ""
+                python3 /key4hep-spack/scripts/fetch_nightly_versions.py --path /key4hep-spack/environments/key4hep-common/packages.yaml --extra-path /key4hep-spack/environments/key4hep-common-opt/packages.yaml --skip-connection-errors ""
             else
                 echo "Unknown build type"
                 exit 1

--- a/scripts/fetch_nightly_versions.py
+++ b/scripts/fetch_nightly_versions.py
@@ -75,6 +75,11 @@ if __name__ == "__main__":
         help="only merge the packages.yaml files",
         action="store_true",
     )
+    parser.add_argument(
+        "--skip-connection-errors",
+        help="skip packages whose host is unreachable instead of failing",
+        action="store_true",
+    )
     # parser.add_argument(
     #     "--spack",
     #     help="path to the spack.yaml in the nightly environment",
@@ -181,7 +186,14 @@ if __name__ == "__main__":
             gitlab = "https://gitlab.cern.ch/api/v4/projects/%s/repository/commits"
         elif package == "marlinmlflavortagging":
             gitlab = "https://gitlab.desy.de/api/v4/projects/%s/repository/commits"
-        commit = get_latest_commit(package, location, date=date, gitlab=gitlab)
+        try:
+            commit = get_latest_commit(package, location, date=date, gitlab=gitlab)
+        except requests.exceptions.ConnectionError as e:
+            if args.skip_connection_errors:
+                print(f"Warning: Could not reach host for {package}, skipping: {e}")
+                continue
+            raise
+
         line = f"@{commit}"
         if package not in ["cepcsw"]:
             line += "=develop"


### PR DESCRIPTION
They happen a lot with MarlinMLFlavorTagging, that is hosted in gitlab.desy.de