### PR TITLE
fix: handle upstream mv spack.llnl.util.tty => spack.util.tty in common.py

### DIFF
--- a/packages/key4hep-stack/common.py
+++ b/packages/key4hep-stack/common.py
@@ -21,10 +21,7 @@ from spack.package_base import PackageBase
 try:
     import spack.util.tty as tty
 except:
-    try:
-        import spack.llnl.util.tty as tty
-    except:
-        import llnl.util.tty as tty
+    import spack.llnl.util.tty as tty
 
 from shlex import quote as cmd_quote
 

--- a/packages/key4hep-stack/common.py
+++ b/packages/key4hep-stack/common.py
@@ -19,9 +19,12 @@ from spack.store import STORE
 from spack.package_base import PackageBase
 
 try:
-    import spack.llnl.util.tty as tty
+    import spack.util.tty as tty
 except:
-    import llnl.util.tty as tty
+    try:
+        import spack.llnl.util.tty as tty
+    except:
+        import llnl.util.tty as tty
 
 from shlex import quote as cmd_quote
 


### PR DESCRIPTION
This fixes issues when running key4hep-spack against upstream spack:develop, e.g. https://github.com/eic/eic-spack/actions/runs/28888198483/job/85693720487?pr=975#step:10:23

BEGINRELEASENOTES
- fix: handle upstream mv spack.llnl.util.tty => spack.util.tty in common.py

ENDRELEASENOTES
