### PR TITLE
Pin GitHub Actions to commit hashes

### DIFF
--- a/.github/workflows/concretize-current-nightly.yaml
+++ b/.github/workflows/concretize-current-nightly.yaml
@@ -22,7 +22,7 @@ jobs:
         build_type: [nightly]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
       - name: Start container
         run: |
             name=$(echo "${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')

--- a/.github/workflows/concretize-latest-spack-packages.yaml
+++ b/.github/workflows/concretize-latest-spack-packages.yaml
@@ -22,7 +22,7 @@ jobs:
         image: [alma9, ubuntu24]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
       - name: Start container
         run: |
             name=$(echo "${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')

--- a/.github/workflows/concretize-nightly-latest-spack.yaml
+++ b/.github/workflows/concretize-nightly-latest-spack.yaml
@@ -23,7 +23,7 @@ jobs:
         image: [alma9, ubuntu24]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
       - name: Start container
         run: |
             name=$(echo "${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')

--- a/.github/workflows/concretize.yaml
+++ b/.github/workflows/concretize.yaml
@@ -20,7 +20,7 @@ jobs:
         build_type: [release, nightly]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
       - name: Start container
         run: |
             name=$(echo "${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')

--- a/.github/workflows/docker-build-push-template.yaml
+++ b/.github/workflows/docker-build-push-template.yaml
@@ -35,7 +35,7 @@ jobs:
       image-uri: ${{ inputs.registry }}/${{ github.repository_owner }}/key4hep-externals-${{ inputs.os }}:${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}-${{ inputs.platform }}@${{ steps.build.outputs.digest }}
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: endersonmenezes/free-disk-space@v3
+        uses: endersonmenezes/free-disk-space@7901478139cff6e9d44df5972fd8ab8fcade4db1 #v3
         with:
           remove_android: true
           remove_dotnet: true
@@ -47,20 +47,20 @@ jobs:
           remove_folders: "/usr/share/swift /usr/share/miniconda /usr/share/az* /usr/share/glade* /usr/local/lib/node_modules /usr/local/share/chromium /usr/local/share/powershell"
           testing: false
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           fetch-depth: 0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c #v4
       - name: Login to Docker Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 #v4
         with:
           registry: ${{ inputs.registry }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker Meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 #v5
         with:
           images: ${{ inputs.registry }}/${{ github.repository_owner }}/key4hep-externals-${{ inputs.os }}
           flavor: latest=false,suffix=-${{ inputs.platform }}
@@ -71,7 +71,7 @@ jobs:
           echo "spack_packages_ref=$(cat .latest-packages-commit)" >>${GITHUB_OUTPUT}
       - name: Build and Push
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 #v6
         with:
           push: true
           platforms: linux/${{ inputs.platform }}

--- a/.github/workflows/image-template.yaml
+++ b/.github/workflows/image-template.yaml
@@ -43,20 +43,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login to DockerHub
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 #v4
         with:
           registry: ${{ inputs.registry }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker Meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 #v5
         with:
           images: ${{ inputs.registry }}/${{ github.repository_owner }}/key4hep-externals-${{ inputs.os }}
           flavor: latest=${{ github.ref == 'refs/heads/main' }}
       - name: Create manifest
         id: build
-        uses: int128/docker-manifest-create-action@v2
+        uses: int128/docker-manifest-create-action@a0bcb6430fe0047c0558deab102a6c66c373dae2 #v2
         with:
           index-annotations: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,8 +9,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 #v6
       with:
         python-version: '3.10'
-    - uses: pre-commit/action@v3.0.0
+    - uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507 #v3.0.0

--- a/.github/workflows/test-setup-scripts.yaml
+++ b/.github/workflows/test-setup-scripts.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up cvmfs
         run: /mount.sh
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
 
       - name: Source nightlies setup script (opt)
         run: source scripts/cvmfs/setup-nightlies.sh
@@ -66,7 +66,7 @@ jobs:
       - name: Set up cvmfs
         run: /mount.sh
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
 
       - name: Source releases setup script (opt)
         run: source scripts/cvmfs/setup-releases.sh


### PR DESCRIPTION
Replace all floating version tags in workflow files with pinned commit SHAs for supply-chain security.

Each pin includes a `#vX` comment so Dependabot still knows the version line to update.